### PR TITLE
Do not expose a (blocking) SessionFactory bean for reactive persistence units

### DIFF
--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/NoJtaTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/NoJtaTest.java
@@ -8,15 +8,15 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
-import org.hibernate.SessionFactory;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
 import org.hibernate.reactive.mutiny.Mutiny;
+import org.hibernate.reactive.mutiny.impl.MutinySessionFactoryImpl;
 import org.hibernate.resource.transaction.spi.TransactionCoordinatorBuilder;
-import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.hibernate.service.ServiceRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkus.arc.ClientProxy;
 import io.quarkus.test.QuarkusUnitTest;
 import io.quarkus.test.vertx.RunOnVertxContext;
 import io.quarkus.test.vertx.UniAsserter;
@@ -30,15 +30,12 @@ public class NoJtaTest {
                     .addAsResource("application.properties"));
 
     @Inject
-    SessionFactory sessionFactory; // This is an ORM SessionFactory, but it's backing Hibernate Reactive.
-
-    @Inject
     Mutiny.SessionFactory factory;
 
     @Test
     @RunOnVertxContext
     public void test(UniAsserter asserter) {
-        ServiceRegistryImplementor serviceRegistry = sessionFactory.unwrap(SessionFactoryImplementor.class)
+        ServiceRegistry serviceRegistry = ((MutinySessionFactoryImpl) ClientProxy.unwrap(factory))
                 .getServiceRegistry();
 
         // Two assertions are necessary, because these values are influenced by separate configuration

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/CompatibilityUnitTestBase.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/compatibility/CompatibilityUnitTestBase.java
@@ -8,9 +8,7 @@ import java.util.Optional;
 import jakarta.persistence.EntityManager;
 
 import org.hibernate.SessionFactory;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.reactive.mutiny.Mutiny;
-import org.hibernate.reactive.session.impl.ReactiveSessionFactoryImpl;
 
 import io.quarkus.arc.Arc;
 import io.quarkus.hibernate.reactive.entities.Hero;
@@ -59,7 +57,7 @@ public abstract class CompatibilityUnitTestBase {
 
     public void testBlockingDisabled() {
         SessionFactory sessionFactory = Arc.container().instance(SessionFactory.class).get();
-        SessionFactoryImplementor unwrapped = sessionFactory.unwrap(SessionFactoryImplementor.class);
-        assertThat(unwrapped).isInstanceOf(ReactiveSessionFactoryImpl.class);
+
+        assertThat(sessionFactory).isNull();
     }
 }

--- a/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/ConfigActiveFalseAndEntityTest.java
+++ b/extensions/hibernate-reactive/deployment/src/test/java/io/quarkus/hibernate/reactive/config/ConfigActiveFalseAndEntityTest.java
@@ -2,12 +2,9 @@ package io.quarkus.hibernate.reactive.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import jakarta.enterprise.inject.CreationException;
-import jakarta.persistence.EntityManagerFactory;
 
-import org.hibernate.SessionFactory;
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -22,40 +19,6 @@ public class ConfigActiveFalseAndEntityTest {
             .withApplicationRoot(jar -> jar.addClass(MyEntity.class))
             .withConfigurationResource("application.properties")
             .overrideConfigKey("quarkus.hibernate-orm.active", "false");
-
-    @Test
-    public void entityManagerFactory() {
-        EntityManagerFactory entityManagerFactory = Arc.container().instance(EntityManagerFactory.class).get();
-
-        // The bean is always available to be injected during static init
-        // since we don't know whether Hibernate Reactive will be active at runtime.
-        // So the bean cannot be null.
-        assertThat(entityManagerFactory).isNotNull();
-        // However, any attempt to use it at runtime will fail.
-        CreationException e = assertThrows(CreationException.class, () -> entityManagerFactory.getMetamodel());
-        assertThat(e.getCause())
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContainingAll(
-                        "Cannot retrieve the EntityManagerFactory/SessionFactory for persistence unit default-reactive",
-                        "Hibernate ORM was deactivated through configuration properties");
-    }
-
-    @Test
-    public void sessionFactory() {
-        SessionFactory sessionFactory = Arc.container().instance(SessionFactory.class).get();
-
-        // The bean is always available to be injected during static init
-        // since we don't know whether Hibernate Reactive will be active at runtime.
-        // So the bean cannot be null.
-        assertThat(sessionFactory).isNotNull();
-        // However, any attempt to use it at runtime will fail.
-        CreationException e = assertThrows(CreationException.class, () -> sessionFactory.getMetamodel());
-        assertThat(e.getCause())
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContainingAll(
-                        "Cannot retrieve the EntityManagerFactory/SessionFactory for persistence unit default-reactive",
-                        "Hibernate ORM was deactivated through configuration properties");
-    }
 
     @Test
     public void mutinySessionFactory() {

--- a/integration-tests/hibernate-reactive-mssql/src/main/java/io/quarkus/it/hibernate/reactive/mssql/DialectEndpoint.java
+++ b/integration-tests/hibernate-reactive-mssql/src/main/java/io/quarkus/it/hibernate/reactive/mssql/DialectEndpoint.java
@@ -8,20 +8,23 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-import org.hibernate.SessionFactory;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.hibernate.reactive.mutiny.impl.MutinySessionFactoryImpl;
 
+import io.quarkus.arc.ClientProxy;
 import io.quarkus.hibernate.orm.runtime.config.DialectVersions;
 
 @Path("/dialect/version")
 @Produces(MediaType.TEXT_PLAIN)
 public class DialectEndpoint {
     @Inject
-    SessionFactory sessionFactory;
+    Mutiny.SessionFactory sessionFactory;
 
     @GET
     public String test() throws IOException {
-        var version = sessionFactory.unwrap(SessionFactoryImplementor.class).getJdbcServices().getDialect().getVersion();
+        var version = ((MutinySessionFactoryImpl) ClientProxy.unwrap(sessionFactory)).getServiceRegistry()
+                .requireService(JdbcServices.class).getDialect().getVersion();
         return DialectVersions.toString(version);
     }
 


### PR DESCRIPTION
It was previously exposed only for internal reasons, due to how the Mutiny.SessionFactory bean was exposed.
With Mutiny,.SessionFactory now being clearly independent, we no longer have a reason to do this,
and we can clean things up.

NOTE: I had to change some conditions which disabled some Hibernate ORM-related code at build time for the sole reason that Hibernate Reactive was around. IMO that's wrong, because Hibernate Reactive can be used together with Hibernate ORM, in which case all the build code relevant to Hibernate ORM must still run.